### PR TITLE
Fix save error in AddressSearch by modifying ip column type

### DIFF
--- a/db/migrate/20210917192402_modify_ip_type_in_address_searches.rb
+++ b/db/migrate/20210917192402_modify_ip_type_in_address_searches.rb
@@ -1,0 +1,13 @@
+class ModifyIpTypeInAddressSearches < ActiveRecord::Migration[6.1]
+  def up
+    change_table :address_searches do |t|
+      t.change :ip, :bigint
+    end
+  end
+
+  def down
+    change_table :address_searches do |t|
+      t.change :ip, :integer
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_06_204327) do
+ActiveRecord::Schema.define(version: 2021_09_17_192402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 2021_02_06_204327) do
     t.string "name"
     t.float "latitude"
     t.float "longitude"
-    t.integer "ip"
+    t.bigint "ip"
     t.float "closest_site_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
Migration to change ip column type from integer to bigint
This fixes the save error which occurred for large IP address value